### PR TITLE
Add gson type factory adapter to handled modded enums

### DIFF
--- a/src/com/massivecraft/mcore/MCore.java
+++ b/src/com/massivecraft/mcore/MCore.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.PlayerInventory;
 import com.massivecraft.mcore.adapter.InventoryAdapter;
 import com.massivecraft.mcore.adapter.ItemStackAdapter;
 import com.massivecraft.mcore.adapter.JsonElementAdapter;
+import com.massivecraft.mcore.adapter.ModdedEnumTypeAdapter;
 import com.massivecraft.mcore.adapter.ObjectIdAdapter;
 import com.massivecraft.mcore.adapter.PlayerInventoryAdapter;
 import com.massivecraft.mcore.adapter.UUIDAdapter;
@@ -82,7 +83,8 @@ public class MCore extends MPlugin
 		.registerTypeAdapter(ItemStack.class, ItemStackAdapter.get())
 		.registerTypeAdapter(Inventory.class, InventoryAdapter.get())
 		.registerTypeAdapter(PlayerInventory.class, PlayerInventoryAdapter.get())
-		.registerTypeAdapter(PS.class, PSAdapter.get());
+		.registerTypeAdapter(PS.class, PSAdapter.get())
+        .registerTypeAdapterFactory(ModdedEnumTypeAdapter.ENUM_FACTORY);
 	}
 	
 	public static String getServerId() { return ConfServer.serverid; }

--- a/src/com/massivecraft/mcore/adapter/ModdedEnumTypeAdapter.java
+++ b/src/com/massivecraft/mcore/adapter/ModdedEnumTypeAdapter.java
@@ -1,0 +1,64 @@
+package com.massivecraft.mcore.adapter;
+
+import com.massivecraft.mcore.xlib.gson.Gson;
+import com.massivecraft.mcore.xlib.gson.TypeAdapter;
+import com.massivecraft.mcore.xlib.gson.TypeAdapterFactory;
+import com.massivecraft.mcore.xlib.gson.annotations.SerializedName;
+import com.massivecraft.mcore.xlib.gson.reflect.TypeToken;
+import com.massivecraft.mcore.xlib.gson.stream.JsonReader;
+import com.massivecraft.mcore.xlib.gson.stream.JsonToken;
+import com.massivecraft.mcore.xlib.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ModdedEnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
+        private final Map<String, T> nameToConstant = new HashMap<String, T>();
+        private final Map<T, String> constantToName = new HashMap<T, String>();
+
+        public ModdedEnumTypeAdapter(Class<T> classOfT) {
+            for (T constant : classOfT.getEnumConstants()) {
+                String name = constant.name();
+                // Ignore when the field can't be found since modified enums won't have it
+                // which is fine, since it wouldn't have an annotation anyway (how could it?)
+                try {
+                    SerializedName annotation = classOfT.getField(name).getAnnotation(SerializedName.class);
+                    if (annotation != null) {
+                        name = annotation.value();
+                    }
+                } catch (NoSuchFieldException ex) {}
+                nameToConstant.put(name, constant);
+                constantToName.put(constant, name);
+            }
+        }
+        public T read(JsonReader in) throws IOException {
+            if (in.peek() == JsonToken.NULL) {
+                in.nextNull();
+                return null;
+            }
+            return nameToConstant.get(in.nextString());
+        }
+
+        public void write(JsonWriter out, T value) throws IOException {
+            out.value(value == null ? null : constantToName.get(value));
+        }
+
+    public static final TypeAdapterFactory ENUM_FACTORY = newEnumTypeHierarchyFactory();
+
+    public static <TT> TypeAdapterFactory newEnumTypeHierarchyFactory() {
+        return new TypeAdapterFactory() {
+            @SuppressWarnings({"rawtypes", "unchecked"})
+            public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+                Class<? super T> rawType = typeToken.getRawType();
+                if (!Enum.class.isAssignableFrom(rawType) || rawType == Enum.class) {
+                    return null;
+                }
+                if (!rawType.isEnum()) {
+                    rawType = rawType.getSuperclass(); // handle anonymous subclasses
+                }
+                return (TypeAdapter<T>) new ModdedEnumTypeAdapter(rawType);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Added a EnumTypeAdapter (w/ Factory) and registered it Gson that it properly handles modified Java Enums.
### Problem:

The problem that was occurring is Forge modifies Vanilla Minecraft Enums (see https://github.com/MinecraftForge/MinecraftForge/blob/master/common/net/minecraftforge/common/EnumHelper.java) -- the way that it modifies the Enum is pure Java hackery modifying $VALUES on the underlying Enum. This will update the calls to `Class.getEnumContants` but won't update any fields on the Enum. So when the built-in Gson `EnumTypeAdaper` tries to see if any `SerializedName` annotations are on the fields of the Enum, it can't find a field with the new names and throws an exception.
### Reasoning:

There is really not any way that we could put any fix in on the MCPC+ side (and if you ever did a Forge port, you'd need this code for that as well) since we can't add fields to Java enums at runtime.
### Solution:

This `ModdedEnumTypeAdapter` is basically just a straight copy of the built-in one, but ignores when it can't find the field/annotation (which is the desired behavior in this case anyways).

I tested this with Factions on the latest MCPC+ release and it resolves the issue that was logged. Hopefully this will reduce the number of people opening issues on both sides. If you have any questions, feel free to hit me up on IRC.
