### PR TITLE
Added support for norwegian & danish vowels

### DIFF
--- a/src/main/java/com/massivecraft/massivecore/util/Txt.java
+++ b/src/main/java/com/massivecraft/massivecore/util/Txt.java
@@ -32,7 +32,7 @@ public class Txt
 	public static final long millisPerYear = 365 * millisPerDay;
 	
 	public static final Set<String> vowel = MUtil.set(
-		"A", "E", "I", "O", "U", "Y", "Å", "Ä", "Ö", "Æ", "Ø"
+		"A", "E", "I", "O", "U", "Y", "Å", "Ä", "Ö", "Æ", "Ø",
 		"a", "e", "i", "o", "u", "y", "å", "ä", "ö", "æ", "ø"
 	); 
 	


### PR DESCRIPTION
The norwegian & danish alphabet contains "Æ" & "Ø" which was not a part of the vowels set.
TBH I have no clue if this makes any difference.
