### PR TITLE
Hacky command support

### DIFF
--- a/src/main/java/com/massivecraft/massivecore/cmd/MassiveCoreBukkitCommand.java
+++ b/src/main/java/com/massivecraft/massivecore/cmd/MassiveCoreBukkitCommand.java
@@ -8,12 +8,14 @@ import java.util.TreeSet;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.plugin.Plugin;
 
 import com.massivecraft.massivecore.mixin.Mixin;
 import com.massivecraft.massivecore.util.IdUtil;
 import com.massivecraft.massivecore.util.Txt;
 
-public class MassiveCoreBukkitCommand extends Command
+public class MassiveCoreBukkitCommand extends Command implements PluginIdentifiableCommand
 {
 	// -------------------------------------------- //
 	// FIELDS
@@ -93,6 +95,16 @@ public class MassiveCoreBukkitCommand extends Command
 		}
 		
 		return new ArrayList<String>(ret);
+	}
+	
+	// -------------------------------------------- //
+	// OVERRIDE: PLUGIN IDENTIFIABLE COMMAND
+	// -------------------------------------------- //
+	
+	@Override
+	public Plugin getPlugin()
+	{
+		return massiveCommand.getRegisteredPlugin();
 	}
 	
 }


### PR DESCRIPTION
Some plugins (PerWorldPlugins) use a hacky command structure like MassiveCore does.
Their command strcuture aims to limit plugins per world. But thus they must know the plugin, this will make it easier for them to find such plugin (and hopefully also others).
Since they don't need explicit MassiveCore support (which was also outdated).
Atleast it doesn't hurt us :)
