### PR TITLE
Player change block event.

### DIFF
--- a/src/com/massivecraft/massivecore/MassiveCoreEngineMain.java
+++ b/src/com/massivecraft/massivecore/MassiveCoreEngineMain.java
@@ -15,21 +15,15 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageByBlockEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result;
-import org.bukkit.event.player.PlayerKickEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerChatTabCompleteEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 
 import com.massivecraft.massivecore.event.EventMassiveCoreAfterPlayerRespawn;
 import com.massivecraft.massivecore.event.EventMassiveCoreAfterPlayerTeleport;
 import com.massivecraft.massivecore.event.EventMassiveCorePermissionDeniedFormat;
 import com.massivecraft.massivecore.event.EventMassiveCorePlayerLeave;
+import com.massivecraft.massivecore.event.EventMassiveCorePlayerMoveBlock;
 import com.massivecraft.massivecore.event.EventMassiveCorePlayerToRecipientChat;
 import com.massivecraft.massivecore.event.EventMassiveCoreSenderRegister;
 import com.massivecraft.massivecore.event.EventMassiveCoreSenderUnregister;
@@ -37,6 +31,7 @@ import com.massivecraft.massivecore.mixin.Mixin;
 import com.massivecraft.massivecore.store.Coll;
 import com.massivecraft.massivecore.store.SenderColl;
 import com.massivecraft.massivecore.util.IdUtil;
+import com.massivecraft.massivecore.util.MUtil;
 import com.massivecraft.massivecore.util.SmokeUtil;
 import com.massivecraft.massivecore.xlib.gson.JsonElement;
 
@@ -170,6 +165,17 @@ public class MassiveCoreEngineMain extends EngineAbstract
 		
 		// ... then cancel the event and the damage.
 		event.setCancelled(true);
+	}
+	
+	// -------------------------------------------- //
+	// CHANGE BLOCK
+	// -------------------------------------------- //
+	
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void playerChangeBlock(PlayerMoveEvent event)
+	{
+		if (MUtil.isSameBlock(event)) return;
+		new EventMassiveCorePlayerMoveBlock(event).run();
 	}
 	
 	// -------------------------------------------- //

--- a/src/com/massivecraft/massivecore/event/EventMassiveCorePlayerMoveBlock.java
+++ b/src/com/massivecraft/massivecore/event/EventMassiveCorePlayerMoveBlock.java
@@ -1,0 +1,51 @@
+package com.massivecraft.massivecore.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import com.massivecraft.massivecore.ps.PS;
+
+public class EventMassiveCorePlayerMoveBlock extends EventMassiveCore
+{
+	// -------------------------------------------- //
+	// REQUIRED EVENT CODE
+	// -------------------------------------------- //
+	
+	private static final HandlerList handlers = new HandlerList();
+	@Override public HandlerList getHandlers() { return handlers; }
+	public static HandlerList getHandlerList() { return handlers; }
+	
+	// -------------------------------------------- //
+	// FIELDS
+	// -------------------------------------------- //
+	
+	// Bukkit event
+	private final PlayerMoveEvent bukkitEvent;
+	public PlayerMoveEvent getBukkitEvent() { return this.bukkitEvent; }
+	
+	private final PS from;
+	public PS getFromPs() { return this.from; }
+	
+	private final PS to;
+	public PS getToPs() { return this.to; }
+	
+	// This event is just for monitoring & will not be thrown if the bukkit event was cancelled.
+	@Override public boolean isCancelled() { return false; }
+	@Override public void setCancelled(boolean cancel) { throw new UnsupportedOperationException("This event is only for watching not modifying."); }
+	
+	// Fake fields
+	public Player getPlayer() { return this.getBukkitEvent().getPlayer(); }
+	
+	// -------------------------------------------- //
+	// CONSTRCUT
+	// -------------------------------------------- //
+	
+	public EventMassiveCorePlayerMoveBlock(PlayerMoveEvent bukkitEvent)
+	{
+		this.bukkitEvent = bukkitEvent;
+		from = PS.valueOf(bukkitEvent.getFrom());
+		to = PS.valueOf(bukkitEvent.getTo());
+	}
+	
+}

--- a/src/com/massivecraft/massivecore/teleport/EngineScheduledTeleport.java
+++ b/src/com/massivecraft/massivecore/teleport/EngineScheduledTeleport.java
@@ -9,14 +9,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.plugin.Plugin;
 
 import com.massivecraft.massivecore.EngineAbstract;
 import com.massivecraft.massivecore.MassiveCore;
+import com.massivecraft.massivecore.event.EventMassiveCorePlayerMoveBlock;
 import com.massivecraft.massivecore.mixin.Mixin;
 import com.massivecraft.massivecore.util.IdUtil;
-import com.massivecraft.massivecore.util.MUtil;
 
 public class EngineScheduledTeleport extends EngineAbstract
 {
@@ -106,12 +105,9 @@ public class EngineScheduledTeleport extends EngineAbstract
 	}
 	
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void cancelTeleport(PlayerMoveEvent event)
+	public void cancelTeleport(EventMassiveCorePlayerMoveBlock event)
 	{
-		// If the player moved from one block to another ...
-		if (MUtil.isSameBlock(event.getFrom(), event.getTo())) return;
-		
-		// ... cancel teleport!
+		// If the player moved from one block to another cancel teleport!
 		this.cancelTeleport(event.getPlayer());
 	}
 	

--- a/src/com/massivecraft/massivecore/util/PlayerUtil.java
+++ b/src/com/massivecraft/massivecore/util/PlayerUtil.java
@@ -15,8 +15,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerAnimationEvent;
 import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
@@ -28,9 +28,10 @@ import org.bukkit.plugin.Plugin;
 
 import com.massivecraft.massivecore.EngineAbstract;
 import com.massivecraft.massivecore.MassiveCore;
-import com.massivecraft.massivecore.event.EventMassiveCorePlayerUpdate;
 import com.massivecraft.massivecore.event.EventMassiveCoreAfterPlayerRespawn;
 import com.massivecraft.massivecore.event.EventMassiveCoreAfterPlayerTeleport;
+import com.massivecraft.massivecore.event.EventMassiveCorePlayerMoveBlock;
+import com.massivecraft.massivecore.event.EventMassiveCorePlayerUpdate;
 
 public class PlayerUtil extends EngineAbstract
 {
@@ -136,9 +137,8 @@ public class PlayerUtil extends EngineAbstract
 	}
 	
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void setLastMoveMillis(PlayerMoveEvent event)
+	public void setLastMoveMillis(EventMassiveCorePlayerMoveBlock event)
 	{
-		if (MUtil.isSameBlock(event)) return;
 		setLastMoveMillis(event.getPlayer());
 	}
 	


### PR DESCRIPTION
Several MassiveCore plugins listen for when a player moves block.
Now it is even easier because of this event.