### PR TITLE
ParticleEffect versioning bug fix.

### DIFF
--- a/src/com/massivecraft/massivecore/particleeffect/ParticleEffect.java
+++ b/src/com/massivecraft/massivecore/particleeffect/ParticleEffect.java
@@ -1409,6 +1409,11 @@ public enum ParticleEffect {
 		 * @return The version number
 		 */
 		public static int getVersion() {
+			// MASSIVECORE MODIFICATION START (Ensure initialized)
+			if (!initialized) {
+				initialize();
+			}
+			// MASSIVECORE MODIFICATION END (Ensure initialized)
 			return version;
 		}
 


### PR DESCRIPTION
This is a partial bug fix until it is updated in the main repo for the library.
Sometimes the version was not gotten adn was the default 0.
This will make sure that the version is always loaded.