### PR TITLE
Typo: parce -> parse

### DIFF
--- a/src/com/massivecraft/massivecore/util/Txt.java
+++ b/src/com/massivecraft/massivecore/util/Txt.java
@@ -68,7 +68,7 @@ public class Txt
 	
 	static
 	{
-		// Create the parce replacements map
+		// Create the parse replacements map
 		parseReplacements = new HashMap<String, String>();
 		
 		// Color by name


### PR DESCRIPTION
Was browsing this brilliant project for some inspiration, bound to catch a typo!
