### PR TITLE
Ignore Maven POM file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,14 +17,15 @@
 .*.sw[a-p]
 
 # Maven
-/build.xml
 /target
+/pom.xml
 /dependency-reduced-pom.xml
 
 # various other potential build files
 /build
 /bin
 /dist
+/build.xml
 /manifest.mf
 
 # Mac filesystem dust


### PR DESCRIPTION
Screwed up the last PR with an accidental merge commit.

Commit adds the missing ignore rule for maven POM files and moves the build.xml ignore rule to the correct section.
