### PR TITLE
Added MongoDB sided filtering for issue #293

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>Vault</artifactId>
         </dependency>
+        <!-- Apache commons IO -->
+        <dependency>
+        	<groupId>commons-io</groupId>
+        	<artifactId>commons-io</artifactId>
+        	<version>2.5</version>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/src/com/massivecraft/massivecore/store/Coll.java
+++ b/src/com/massivecraft/massivecore/store/Coll.java
@@ -1136,4 +1136,15 @@ public class Coll<E extends Entity<E>> extends CollAbstract<E>
 		return this.getByName(str) != null;
 	}
 	
+	@Override
+	public List<E> getAll(JsonObject filter) {
+		List<E> ret = new ArrayList<E>();
+		for(Entry<String, Entry<JsonObject, Long>> idToEntry : this.getDb().loadFilter(this, filter).entrySet()){
+			// Does this load it twice?
+			E e = this.getFixed(idToEntry.getKey());
+			ret.add(e);
+		}
+		return ret;
+	}
+	
 }

--- a/src/com/massivecraft/massivecore/store/CollInterface.java
+++ b/src/com/massivecraft/massivecore/store/CollInterface.java
@@ -59,6 +59,8 @@ public interface CollInterface<E extends Entity<E>> extends Named, Active, Ident
 	
 	public Collection<E> getAll();
 	
+	public List<E> getAll(JsonObject filter);
+	
 	public List<E> getAll(Iterable<?> oids, Predicate<? super E> where, Comparator<? super E> orderby, Integer limit, Integer offset);
 	public List<E> getAll(Iterable<?> oids, Predicate<? super E> where, Comparator<? super E> orderby, Integer limit);
 	public List<E> getAll(Iterable<?> oids, Predicate<? super E> where, Comparator<? super E> orderby);

--- a/src/com/massivecraft/massivecore/store/Db.java
+++ b/src/com/massivecraft/massivecore/store/Db.java
@@ -37,6 +37,7 @@ public interface Db
 	public Collection<String> getIds(Coll<?> coll);
 	public Map<String, Long> getId2mtime(Coll<?> coll);
 	public Entry<JsonObject, Long> load(Coll<?> coll, String id);
+	public Map<String, Entry<JsonObject, Long>> loadFilter(Coll<?> coll, JsonObject filter);
 	public Map<String, Entry<JsonObject, Long>> loadAll(Coll<?> coll);
 	public long save(Coll<?> coll, String id, JsonObject data);
 	public void delete(Coll<?> coll, String id);

--- a/src/com/massivecraft/massivecore/store/DbAbstract.java
+++ b/src/com/massivecraft/massivecore/store/DbAbstract.java
@@ -63,6 +63,10 @@ public abstract class DbAbstract implements Db
 		return this.getDriver().load(coll, id);
 	}
 	
+	public Map<String, Entry<JsonObject, Long>> loadFilter(Coll<?> coll, JsonObject filter){
+		return this.loadFilter(coll, filter);
+	}
+	
 	public Map<String, Entry<JsonObject, Long>> loadAll(Coll<?> coll)
 	{
 		return this.getDriver().loadAll(coll);

--- a/src/com/massivecraft/massivecore/store/Driver.java
+++ b/src/com/massivecraft/massivecore/store/Driver.java
@@ -44,6 +44,12 @@ public interface Driver
 	// return.getKey() == null || return.getValue() == 0 means something failed.
 	public Entry<JsonObject, Long> load(Coll<?> coll, String id);
 	
+	// Download exactly the needed files using filtering at the MongoDB end,
+	// which is originally not possible in MassiveCore since every filtering
+	// is done at the Java end rather than the MongoDB end. Also works for
+	// flatfile, should increase overall performance.
+	public Map<String, Entry<JsonObject, Long>> loadFilter(Coll<?> coll, JsonObject filter);
+	
 	// Load all database content at once
 	// NOTE: This method is assumed to be based on the one above.
 	// NOTE: Values where JsonObject == null and Long == 0 may occur.

--- a/src/com/massivecraft/massivecore/store/DriverFlatfile.java
+++ b/src/com/massivecraft/massivecore/store/DriverFlatfile.java
@@ -16,6 +16,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import com.massivecraft.massivecore.util.DiscUtil;
+import com.massivecraft.massivecore.xlib.gson.JsonElement;
 import com.massivecraft.massivecore.xlib.gson.JsonObject;
 import com.massivecraft.massivecore.xlib.gson.JsonParser;
 
@@ -146,6 +147,43 @@ public class DriverFlatfile extends DriverAbstract
 	{
 		File file = fileFromId(coll, id);
 		return loadFile(file);
+	}
+	
+	@Override
+	public Map<String, Entry<JsonObject, Long>> loadFilter(Coll<?> coll, JsonObject filter){
+		// Create Ret
+		Map<String, Entry<JsonObject, Long>> ret = null;
+		
+		// Get Directory
+		File directory = getDirectory(coll);
+		if ( ! directory.isDirectory()) return ret;
+		
+		// Find All
+		File[] files = directory.listFiles(JsonFileFilter.get());
+		
+		// Create Ret
+		ret = new LinkedHashMap<String, Entry<JsonObject, Long>>(files.length);
+       
+		// Filter rules
+		Set<Map.Entry<String, JsonElement>> filterRules = filter.entrySet();
+		
+		// For Each Found
+		for (File file : files)
+		{
+			// Get ID
+			String id = idFromFile(file);
+			
+			// Get Entry
+			Entry<JsonObject, Long> entry = loadFile(file);
+			
+			Set<Map.Entry<String, JsonElement>> fileEntries = entry.getKey().entrySet();
+			if (fileEntries.containsAll(filterRules)) {
+				// add to filtered
+				ret.put(id, entry);
+			}
+		}
+		
+        return ret;
 	}
 	
 	public Entry<JsonObject, Long> loadFile(File file)


### PR DESCRIPTION
For my personal project, I must download a huge amount of data for my players very regularly. Having to download milions of documents practicly every second was a no-go for me as filtering was done by Java rather than MongoDB. This updated driver allows for (mainly) filtering by MongoDB, so I only download the documents that I need, rather than downloading half the database.

Should dramaticly improve performance in some cases when using MongoDB. Flatfile might also notice some performance improvement, although I have not tested that.