### PR TITLE
is/setUnbreakable fixes

### DIFF
--- a/src/com/massivecraft/massivecore/item/WriterItemStackMetaUnbreakable.java
+++ b/src/com/massivecraft/massivecore/item/WriterItemStackMetaUnbreakable.java
@@ -1,5 +1,6 @@
 package com.massivecraft.massivecore.item;
 
+import com.massivecraft.massivecore.nms.NmsItemStackMetaUnbreakable;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -35,13 +36,13 @@ public class WriterItemStackMetaUnbreakable extends WriterAbstractItemStackMetaF
 	@Override
 	public Boolean getB(ItemMeta cb, ItemStack d)
 	{
-		return cb.isUnbreakable();
+		return NmsItemStackMetaUnbreakable.get().isUnbreakable(cb);
 	}
 
 	@Override
 	public void setB(ItemMeta cb, Boolean fb, ItemStack d)
 	{
-		cb.setUnbreakable(fb);
+		NmsItemStackMetaUnbreakable.get().setUnbreakable(cb,fb);
 	}
 	
 }

--- a/src/com/massivecraft/massivecore/item/WriterItemStackMetaUnbreakable.java
+++ b/src/com/massivecraft/massivecore/item/WriterItemStackMetaUnbreakable.java
@@ -35,13 +35,13 @@ public class WriterItemStackMetaUnbreakable extends WriterAbstractItemStackMetaF
 	@Override
 	public Boolean getB(ItemMeta cb, ItemStack d)
 	{
-		return cb.spigot().isUnbreakable();
+		return cb.isUnbreakable();
 	}
 
 	@Override
 	public void setB(ItemMeta cb, Boolean fb, ItemStack d)
 	{
-		cb.spigot().setUnbreakable(fb);
+		cb.setUnbreakable(fb);
 	}
 	
 }

--- a/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakable.java
+++ b/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakable.java
@@ -1,0 +1,35 @@
+package com.massivecraft.massivecore.nms;
+
+import com.massivecraft.massivecore.mixin.Mixin;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class NmsItemStackMetaUnbreakable extends Mixin
+{
+	// -------------------------------------------- //
+	// DEFAULT
+	// -------------------------------------------- //
+	
+	private static NmsItemStackMetaUnbreakable d = new NmsItemStackMetaUnbreakable().setAlternatives(
+		NmsItemStackMetaUnbreakableSpigot.class,
+		NmsItemStackMetaUnbreakableFallback.class
+	);
+	
+	// -------------------------------------------- //
+	// INSTANCE & CONSTRUCT
+	// -------------------------------------------- //
+	
+	private static NmsItemStackMetaUnbreakable i = d;
+	public static NmsItemStackMetaUnbreakable get() { return i; }
+
+	// -------------------------------------------- //
+	// ACCESS > UNBREAKABLE
+	// -------------------------------------------- //
+	
+	public boolean isUnbreakable(ItemMeta meta)
+	{
+		throw notImplemented();
+	}
+	
+	public void setUnbreakable(ItemMeta meta, boolean unbreakable) { throw notImplemented(); }
+	
+}

--- a/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakableFallback.java
+++ b/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakableFallback.java
@@ -1,0 +1,34 @@
+package com.massivecraft.massivecore.nms;
+
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class NmsItemStackMetaUnbreakableFallback extends NmsItemStackMetaUnbreakable
+{
+	// -------------------------------------------- //
+	// INSTANCE & CONSTRUCT
+	// -------------------------------------------- //
+	
+	private static NmsItemStackMetaUnbreakableFallback i = new NmsItemStackMetaUnbreakableFallback();
+	public static NmsItemStackMetaUnbreakableFallback get() { return i; }
+	
+	// -------------------------------------------- //
+	// IS UNBREAKABLE
+	// -------------------------------------------- //
+	
+	@SuppressWarnings("deprecation")
+	@Override
+	public boolean isUnbreakable(ItemMeta meta) {
+		return meta.spigot().isUnbreakable();
+	}
+	
+	// -------------------------------------------- //
+	// SET UNBREAKABLE
+	// -------------------------------------------- //
+	
+	@SuppressWarnings("deprecation")
+	@Override
+	public void setUnbreakable(ItemMeta meta, boolean unbreakable) {
+		meta.spigot().setUnbreakable(unbreakable);
+	}
+	
+}

--- a/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakableSpigot.java
+++ b/src/com/massivecraft/massivecore/nms/NmsItemStackMetaUnbreakableSpigot.java
@@ -1,0 +1,50 @@
+package com.massivecraft.massivecore.nms;
+
+import com.massivecraft.massivecore.util.ReflectionUtil;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.lang.reflect.Method;
+
+public class NmsItemStackMetaUnbreakableSpigot extends NmsItemStackMetaUnbreakable
+{
+	// -------------------------------------------- //
+	// INSTANCE & CONSTRUCT
+	// -------------------------------------------- //
+	
+	private static NmsItemStackMetaUnbreakableSpigot i = new NmsItemStackMetaUnbreakableSpigot();
+	public static NmsItemStackMetaUnbreakableSpigot get() { return i; }
+	
+	// -------------------------------------------- //
+	// FIELDS
+	// -------------------------------------------- //
+	
+	//org.bukkit.inventory.meta.ItemMeta#isUnbreakable()
+	private Method bukkitItemMetaIsUnbreakable;
+	//org.bukkit.inventory.meta.ItemMeta#setUnbreakable(Boolean)
+	private Method bukkitItemMetaSetUnbreakable;
+	
+	// -------------------------------------------- //
+	// SETUP
+	// -------------------------------------------- //
+	
+	@Override
+	public void setup() throws Throwable
+	{
+		bukkitItemMetaIsUnbreakable = ReflectionUtil.getMethod(ItemMeta.class,"isUnbreakable");
+		bukkitItemMetaSetUnbreakable = ReflectionUtil.getMethod(ItemMeta.class,"setUnbreakable", boolean.class);
+	}
+	
+	// -------------------------------------------- //
+	// ACCESS > UNBREAKABLE
+	// -------------------------------------------- //
+	
+	public boolean isUnbreakable(ItemMeta meta) {
+		return ReflectionUtil.invokeMethod(bukkitItemMetaIsUnbreakable, meta);
+	}
+	
+	public void setUnbreakable(ItemMeta meta, boolean unbreakable)
+	{
+		ReflectionUtil.invokeMethod(bukkitItemMetaSetUnbreakable, meta, unbreakable);
+	}
+	
+}


### PR DESCRIPTION
ItemMeta.Spigot.setUnbreakable() and isUnbreakable() are deprecated, and throw UnsupportedOperationException exceptions when called.

Changed to ItemMeta.setUnbreakable() and isUnbreakable() as Annotations direct.

These functions were being used in MassiveCore.

Issue noticed through MassiveBooks - Attempting to Save Books on a fresh installation would throw the aforementioned error, and prevented existing installations from loading.