### PR TITLE
Avoid excessive indentation in SignUtil

### DIFF
--- a/src/com/massivecraft/massivecore/util/SignUtil.java
+++ b/src/com/massivecraft/massivecore/util/SignUtil.java
@@ -281,10 +281,8 @@ public class SignUtil
 		for (Block block : blocks)
 		{
 			List<String> lines = getLines(block);
-			if (lines != null)
-			{
-				ret.addAll(lines);
-			}
+			if (lines == null) continue;
+			ret.addAll(lines);
 		}
 		
 		return ret;


### PR DESCRIPTION
Better complies with our formatting standards.