### PR TITLE
Fix parameter index error for mstore stats

### DIFF
--- a/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreStoreStats.java
+++ b/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreStoreStats.java
@@ -33,7 +33,7 @@ public class CmdMassiveCoreStoreStats extends MassiveCoreCommand
 		}
 		else
 		{
-			Coll<?> coll = this.readArg();
+			Coll<?> coll = this.readArgAt(0);
 			this.performColl(coll);
 		}
 	}


### PR DESCRIPTION
The error occurred when trying to check the stats of a specific coll by name.