### PR TITLE
Resolves permission issues with some Massive Core commands.

### DIFF
--- a/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreBuffer.java
+++ b/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreBuffer.java
@@ -10,7 +10,7 @@ public class CmdMassiveCoreBuffer extends MassiveCoreCommand
 	// INSTANCE
 	// -------------------------------------------- //
 	
-	private static CmdMassiveCoreBuffer i = new CmdMassiveCoreBuffer() { public List<String> getAliases() { return MassiveCoreMConf.get().aliasesBuffer; } };
+	private static CmdMassiveCoreBuffer i = new CmdMassiveCoreBuffer();
 	public static CmdMassiveCoreBuffer get() { return i; }
 	
 	// -------------------------------------------- //
@@ -23,4 +23,13 @@ public class CmdMassiveCoreBuffer extends MassiveCoreCommand
 	public CmdMassiveCoreBufferAdd cmdMassiveCoreBufferAdd = new CmdMassiveCoreBufferAdd();
 	public CmdMassiveCoreBufferWhitespace cmdMassiveCoreBufferWhitespace = new CmdMassiveCoreBufferWhitespace();
 	
+	// -------------------------------------------- //
+	// OVERRIDE
+	// -------------------------------------------- //
+	
+	@Override
+	public List<String> getAliases()
+	{
+		return MassiveCoreMConf.get().aliasesBuffer;
+	}
 }

--- a/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreCmdurl.java
+++ b/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreCmdurl.java
@@ -20,7 +20,7 @@ public class CmdMassiveCoreCmdurl extends MassiveCoreCommand
 	// INSTANCE
 	// -------------------------------------------- //
 	
-	private static CmdMassiveCoreCmdurl i = new CmdMassiveCoreCmdurl() { public List<String> getAliases() { return MassiveCoreMConf.get().aliasesCmdurl; } };
+	private static CmdMassiveCoreCmdurl i = new CmdMassiveCoreCmdurl();
 	public static CmdMassiveCoreCmdurl get() { return i; }
 	
 	// -------------------------------------------- //
@@ -108,6 +108,12 @@ public class CmdMassiveCoreCmdurl extends MassiveCoreCommand
 				}
 			}
 		});
+	}
+	
+	@Override
+	public List<String> getAliases()
+	{
+		return MassiveCoreMConf.get().aliasesCmdurl;
 	}
 	
 	// -------------------------------------------- //

--- a/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreStore.java
+++ b/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreStore.java
@@ -10,7 +10,7 @@ public class CmdMassiveCoreStore extends MassiveCoreCommand
 	// INSTANCE
 	// -------------------------------------------- //
 	
-	private static CmdMassiveCoreStore i = new CmdMassiveCoreStore() { public List<String> getAliases() { return MassiveCoreMConf.get().aliasesMstore; } };
+	private static CmdMassiveCoreStore i = new CmdMassiveCoreStore();
 	public static CmdMassiveCoreStore get() { return i; }
 	
 	// -------------------------------------------- //
@@ -22,4 +22,13 @@ public class CmdMassiveCoreStore extends MassiveCoreCommand
 	public CmdMassiveCoreStoreCopydb cmdMassiveCoreStoreCopydb = new CmdMassiveCoreStoreCopydb();
 	public CmdMassiveCoreStoreClean cmdMassiveCoreStoreClean = new CmdMassiveCoreStoreClean();
 	
+	// -------------------------------------------- //
+	// OVERRIDE
+	// -------------------------------------------- //
+	
+	@Override
+	public List<String> getAliases()
+	{
+		return MassiveCoreMConf.get().aliasesMstore;
+	}
 }

--- a/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreUsys.java
+++ b/src/com/massivecraft/massivecore/cmd/CmdMassiveCoreUsys.java
@@ -10,7 +10,7 @@ public class CmdMassiveCoreUsys extends MassiveCoreCommand
 	// INSTANCE
 	// -------------------------------------------- //
 	
-	private static CmdMassiveCoreUsys i = new CmdMassiveCoreUsys() { public List<String> getAliases() { return MassiveCoreMConf.get().aliasesUsys; } };
+	private static CmdMassiveCoreUsys i = new CmdMassiveCoreUsys();
 	public static CmdMassiveCoreUsys get() { return i; }
 	
 	// -------------------------------------------- //
@@ -21,5 +21,15 @@ public class CmdMassiveCoreUsys extends MassiveCoreCommand
 	public CmdMassiveCoreUsysUniverse cmdMassiveCoreUsysUniverse = new CmdMassiveCoreUsysUniverse();
 	public CmdMassiveCoreUsysWorld cmdMassiveCoreUsysWorld = new CmdMassiveCoreUsysWorld();
 	public CmdMassiveCoreUsysAspect cmdMassiveCoreUsysAspect = new CmdMassiveCoreUsysAspect();
+	
+	// -------------------------------------------- //
+	// OVERRIDE
+	// -------------------------------------------- //
+	
+	@Override
+	public List<String> getAliases()
+	{
+		return MassiveCoreMConf.get().aliasesUsys;
+	}
 	
 }


### PR DESCRIPTION
Prior behavior allowed users to run the commands through their aliases without the necessary permission nodes.